### PR TITLE
Add definitions and commands for nRF9160 full modem firmware update.

### DIFF
--- a/nmxact/nmp/decode.go
+++ b/nmxact/nmp/decode.go
@@ -37,6 +37,7 @@ const gr_cra = NMP_GROUP_CRASH
 const gr_run = NMP_GROUP_RUN
 const gr_fil = NMP_GROUP_FS
 const gr_she = NMP_GROUP_SHELL
+const gr_mfu = NMP_GROUP_FMFU
 
 // Op-Group-Id
 type Ogi struct {
@@ -74,6 +75,7 @@ func fsUploadRspCtor() NmpRsp      { return NewFsUploadRsp() }
 func configReadRspCtor() NmpRsp    { return NewConfigReadRsp() }
 func configWriteRspCtor() NmpRsp   { return NewConfigWriteRsp() }
 func shellExecRspCtor() NmpRsp     { return NewShellExecRsp() }
+func fmfuUploadRspCtor() NmpRsp    { return NewFmfuUploadRsp() }
 
 var rspCtorMap = map[Ogi]rspCtor{
 	{op_wr, gr_def, NMP_ID_DEF_ECHO}:         echoRspCtor,
@@ -104,6 +106,7 @@ var rspCtorMap = map[Ogi]rspCtor{
 	{op_rr, gr_cfg, NMP_ID_CONFIG_VAL}:       configReadRspCtor,
 	{op_wr, gr_cfg, NMP_ID_CONFIG_VAL}:       configWriteRspCtor,
 	{op_wr, gr_she, NMP_ID_SHELL_EXEC}:       shellExecRspCtor,
+	{op_wr, gr_mfu, NMP_ID_FMFU_UPLOAD}:      fmfuUploadRspCtor,
 }
 
 func DecodeRspBody(hdr *NmpHdr, body []byte) (NmpRsp, error) {

--- a/nmxact/nmp/defs.go
+++ b/nmxact/nmp/defs.go
@@ -50,6 +50,7 @@ const (
 	NMP_GROUP_FS      = 8
 	NMP_GROUP_SHELL   = 9
 	NMP_GROUP_PERUSER = 64
+	NMP_GROUP_FMFU    = 65
 )
 
 // Default group (0).
@@ -108,7 +109,13 @@ const (
 	NMP_ID_FS_FILE = 0
 )
 
-// Shell group (8).
+// Shell group (9).
 const (
 	NMP_ID_SHELL_EXEC = 0
+)
+
+// Modem Firmwae Update group (65).
+const (
+	NMP_ID_FMFU_HASH   = 0
+	NMP_ID_FMFU_UPLOAD = 1
 )

--- a/nmxact/nmp/fmfu.go
+++ b/nmxact/nmp/fmfu.go
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package nmp
+
+const SMP_PACKET_MTU = 256
+
+type FmfuUploadReq struct {
+	NmpBase `codec:"-"`
+	Data    []byte `codec:"data"`
+	Length  uint32 `codec:"len"`
+	Offset  uint32 `codec:"off"`
+	Sha     []byte `codec:"sha"`
+	Address uint32 `codec:"addr"`
+}
+
+type FmfuUploadRsp struct {
+	NmpBase `codec:"-"`
+	Rc      int  `codec:"rc"`
+	Offset  uint `codec:"off"`
+}
+
+func NewFmfuUploadReq() *FmfuUploadReq {
+	r := &FmfuUploadReq{}
+	fillNmpReq(r, NMP_OP_WRITE, NMP_GROUP_FMFU, NMP_ID_FMFU_UPLOAD)
+	return r
+}
+
+func (r *FmfuUploadReq) Msg() *NmpMsg { return MsgFromReq(r) }
+
+func NewFmfuUploadRsp() *FmfuUploadRsp {
+	return &FmfuUploadRsp{}
+}
+
+func (r *FmfuUploadRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/xact/fmfu.go
+++ b/nmxact/xact/fmfu.go
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package xact
+
+import (
+	"mynewt.apache.org/newtmgr/nmxact/nmp"
+	"mynewt.apache.org/newtmgr/nmxact/sesn"
+)
+
+// const SMP_PACKET_MTU = 256
+
+type FmfuUploadCmd struct {
+	CmdBase
+	Data    []byte
+	Length  uint32
+	Offset  uint32
+	Sha     []byte
+	Address uint32
+}
+
+func NewFmfuUploadCmd() *FmfuUploadCmd {
+	return &FmfuUploadCmd{
+		CmdBase: NewCmdBase(),
+	}
+}
+
+type FmfuResult struct {
+	Rsp *nmp.FmfuUploadRsp
+}
+
+func newFmfuUploadResult() *FmfuResult {
+	return &FmfuResult{}
+}
+
+func (r *FmfuResult) Status() int {
+	return r.Rsp.Rc
+}
+
+func (c *FmfuUploadCmd) Run(s sesn.Sesn) (Result, error) {
+	r := nmp.NewFmfuUploadReq()
+	r.Data = c.Data
+	r.Length = c.Length
+	r.Offset = c.Offset
+	r.Sha = c.Sha
+	r.Address = c.Address
+
+	rsp, err := txReq(s, r.Msg(), &c.CmdBase)
+	if err != nil {
+		return nil, err
+	}
+	srsp := rsp.(*nmp.FmfuUploadRsp)
+
+	res := newFmfuUploadResult()
+	res.Rsp = srsp
+	return res, nil
+}


### PR DESCRIPTION
For use with Zephyr fmfu-smp-svr-sample.